### PR TITLE
Relayout force squash popup with side diff

### DIFF
--- a/src/Resources/Locales/de_DE.axaml
+++ b/src/Resources/Locales/de_DE.axaml
@@ -763,7 +763,6 @@
   <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">Originalautor und -datum des Ziel-Commits beibehalten</x:String>
   <x:String x:Key="Text.ForceSquash.AppendMessages" xml:space="preserve">Nachrichten der gesquashten Commits an den Body anhängen</x:String>
   <x:String x:Key="Text.ForceSquash.StashPopFailed" xml:space="preserve">Automatischen Stash anwenden fehlgeschlagen.</x:String>
-  <x:String x:Key="Text.ForceSquash.ShowFullDiff" xml:space="preserve">Vollen Diff anzeigen</x:String>
   <x:String x:Key="Text.ForceSquash.Success" xml:space="preserve">Historie abgeflacht. Sicherungszweig: {0}</x:String>
   <x:String x:Key="Text.ForceSquash.SuccessNoBackup" xml:space="preserve">Historie abgeflacht.</x:String>
   <x:String x:Key="Text.SSHKey" xml:space="preserve">SSH privater Schlüssel:</x:String>

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -759,7 +759,6 @@
   <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">Keep original author/date of target commit</x:String>
   <x:String x:Key="Text.ForceSquash.AppendMessages" xml:space="preserve">Append messages of squashed commits to body</x:String>
   <x:String x:Key="Text.ForceSquash.StashPopFailed" xml:space="preserve">Failed to apply auto stash.</x:String>
-  <x:String x:Key="Text.ForceSquash.ShowFullDiff" xml:space="preserve">Show full diff</x:String>
   <x:String x:Key="Text.ForceSquash.Success" xml:space="preserve">History flattened. Backup branch: {0}</x:String>
   <x:String x:Key="Text.ForceSquash.SuccessNoBackup" xml:space="preserve">History flattened.</x:String>
   <x:String x:Key="Text.SSHKey" xml:space="preserve">SSH Private Key:</x:String>

--- a/src/Resources/Locales/es_ES.axaml
+++ b/src/Resources/Locales/es_ES.axaml
@@ -762,7 +762,6 @@
   <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">Conservar autor/fecha originales del commit destino</x:String>
   <x:String x:Key="Text.ForceSquash.AppendMessages" xml:space="preserve">Añadir mensajes de los commits aplastados al cuerpo</x:String>
   <x:String x:Key="Text.ForceSquash.StashPopFailed" xml:space="preserve">No se pudo aplicar el auto-stash.</x:String>
-  <x:String x:Key="Text.ForceSquash.ShowFullDiff" xml:space="preserve">Mostrar diff completo</x:String>
   <x:String x:Key="Text.ForceSquash.Success" xml:space="preserve">Historial aplanado. Rama de respaldo: {0}</x:String>
   <x:String x:Key="Text.ForceSquash.SuccessNoBackup" xml:space="preserve">Historial aplanado.</x:String>
   <x:String x:Key="Text.SSHKey" xml:space="preserve">Clave Privada SSH:</x:String>

--- a/src/Resources/Locales/fr_FR.axaml
+++ b/src/Resources/Locales/fr_FR.axaml
@@ -623,7 +623,6 @@
   <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">Conserver l'auteur/la date originaux du commit cible</x:String>
   <x:String x:Key="Text.ForceSquash.AppendMessages" xml:space="preserve">Ajouter les messages des commits squashés au corps</x:String>
   <x:String x:Key="Text.ForceSquash.StashPopFailed" xml:space="preserve">Échec de l'application de l'auto-stash.</x:String>
-  <x:String x:Key="Text.ForceSquash.ShowFullDiff" xml:space="preserve">Afficher le diff complet</x:String>
   <x:String x:Key="Text.ForceSquash.Success" xml:space="preserve">Historique aplati. Branche de sauvegarde : {0}</x:String>
   <x:String x:Key="Text.ForceSquash.SuccessNoBackup" xml:space="preserve">Historique aplati.</x:String>
   <x:String x:Key="Text.SSHKey" xml:space="preserve">Clé privée SSH :</x:String>

--- a/src/Resources/Locales/it_IT.axaml
+++ b/src/Resources/Locales/it_IT.axaml
@@ -651,7 +651,6 @@
   <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">Mantieni autore/data originali del commit di destinazione</x:String>
   <x:String x:Key="Text.ForceSquash.AppendMessages" xml:space="preserve">Aggiungi i messaggi dei commit squasciati al corpo</x:String>
   <x:String x:Key="Text.ForceSquash.StashPopFailed" xml:space="preserve">Applicazione dell'auto-stash non riuscita.</x:String>
-  <x:String x:Key="Text.ForceSquash.ShowFullDiff" xml:space="preserve">Mostra diff completo</x:String>
   <x:String x:Key="Text.ForceSquash.Success" xml:space="preserve">Cronologia appiattita. Ramo di backup: {0}</x:String>
   <x:String x:Key="Text.ForceSquash.SuccessNoBackup" xml:space="preserve">Cronologia appiattita.</x:String>
   <x:String x:Key="Text.SSHKey" xml:space="preserve">Chiave Privata SSH:</x:String>

--- a/src/Resources/Locales/ja_JP.axaml
+++ b/src/Resources/Locales/ja_JP.axaml
@@ -621,7 +621,6 @@
   <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">対象コミットの元の作者/日付を保持</x:String>
   <x:String x:Key="Text.ForceSquash.AppendMessages" xml:space="preserve">スクワッシュされたコミットのメッセージを本文に追加</x:String>
   <x:String x:Key="Text.ForceSquash.StashPopFailed" xml:space="preserve">自動スタッシュの適用に失敗しました。</x:String>
-  <x:String x:Key="Text.ForceSquash.ShowFullDiff" xml:space="preserve">完全な差分を表示</x:String>
   <x:String x:Key="Text.ForceSquash.Success" xml:space="preserve">履歴を平坦化しました。バックアップブランチ: {0}</x:String>
   <x:String x:Key="Text.ForceSquash.SuccessNoBackup" xml:space="preserve">履歴を平坦化しました。</x:String>
   <x:String x:Key="Text.SSHKey" xml:space="preserve">SSH プライベートキー:</x:String>

--- a/src/Resources/Locales/pt_BR.axaml
+++ b/src/Resources/Locales/pt_BR.axaml
@@ -565,7 +565,6 @@
   <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">Manter autor/data originais do commit de destino</x:String>
   <x:String x:Key="Text.ForceSquash.AppendMessages" xml:space="preserve">Anexar mensagens dos commits squashados ao corpo</x:String>
   <x:String x:Key="Text.ForceSquash.StashPopFailed" xml:space="preserve">Falha ao aplicar auto-stash.</x:String>
-  <x:String x:Key="Text.ForceSquash.ShowFullDiff" xml:space="preserve">Mostrar diff completo</x:String>
   <x:String x:Key="Text.ForceSquash.Success" xml:space="preserve">Histórico achatado. Branch de backup: {0}</x:String>
   <x:String x:Key="Text.ForceSquash.SuccessNoBackup" xml:space="preserve">Histórico achatado.</x:String>
   <x:String x:Key="Text.SSHKey" xml:space="preserve">Chave SSH Privada:</x:String>

--- a/src/Resources/Locales/ru_RU.axaml
+++ b/src/Resources/Locales/ru_RU.axaml
@@ -752,7 +752,6 @@
   <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">Сохранить автора и дату целевого коммита</x:String>
   <x:String x:Key="Text.ForceSquash.AppendMessages" xml:space="preserve">Добавить сообщения объединяемых коммитов в тело</x:String>
   <x:String x:Key="Text.ForceSquash.StashPopFailed" xml:space="preserve">Не удалось применить авто-стэш.</x:String>
-  <x:String x:Key="Text.ForceSquash.ShowFullDiff" xml:space="preserve">Показать полный diff</x:String>
   <x:String x:Key="Text.ForceSquash.Success" xml:space="preserve">История сплюснута. Резервная ветка: {0}</x:String>
   <x:String x:Key="Text.ForceSquash.SuccessNoBackup" xml:space="preserve">История сплюснута.</x:String>
   <x:String x:Key="Text.SSHKey" xml:space="preserve">Приватный ключ SSH:</x:String>

--- a/src/Resources/Locales/ta_IN.axaml
+++ b/src/Resources/Locales/ta_IN.axaml
@@ -622,7 +622,6 @@
   <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">இலக்கு commit-ன் அசல் author/தேதியை வைத்திரு</x:String>
   <x:String x:Key="Text.ForceSquash.AppendMessages" xml:space="preserve">நொறுக்கப்பட்ட commit-களின் செய்திகளை body-க்கு சேர்க்கவும்</x:String>
   <x:String x:Key="Text.ForceSquash.StashPopFailed" xml:space="preserve">Auto stash-ஐ பயன்படுத்த முடியவில்லை.</x:String>
-  <x:String x:Key="Text.ForceSquash.ShowFullDiff" xml:space="preserve">முழு diff-ஐ காட்டு</x:String>
   <x:String x:Key="Text.ForceSquash.Success" xml:space="preserve">வரலாறு சமப்படுத்தப்பட்டது. காப்பு branch: {0}</x:String>
   <x:String x:Key="Text.ForceSquash.SuccessNoBackup" xml:space="preserve">வரலாறு சமப்படுத்தப்பட்டது.</x:String>
   <x:String x:Key="Text.SSHKey" xml:space="preserve">பாஓடு தனியார் திறவுகோல்:</x:String>

--- a/src/Resources/Locales/uk_UA.axaml
+++ b/src/Resources/Locales/uk_UA.axaml
@@ -627,7 +627,6 @@
   <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">Зберегти автора/дату цільового коміту</x:String>
   <x:String x:Key="Text.ForceSquash.AppendMessages" xml:space="preserve">Додати повідомлення сплюснутих комітів у тіло</x:String>
   <x:String x:Key="Text.ForceSquash.StashPopFailed" xml:space="preserve">Не вдалося застосувати автостеш.</x:String>
-  <x:String x:Key="Text.ForceSquash.ShowFullDiff" xml:space="preserve">Показати повний diff</x:String>
   <x:String x:Key="Text.ForceSquash.Success" xml:space="preserve">Історію сплюснуто. Резервна гілка: {0}</x:String>
   <x:String x:Key="Text.ForceSquash.SuccessNoBackup" xml:space="preserve">Історію сплюснуто.</x:String>
   <x:String x:Key="Text.SSHKey" xml:space="preserve">Приватний ключ SSH:</x:String>

--- a/src/Resources/Locales/zh_CN.axaml
+++ b/src/Resources/Locales/zh_CN.axaml
@@ -762,7 +762,6 @@
   <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">保留目标提交的原作者/日期</x:String>
   <x:String x:Key="Text.ForceSquash.AppendMessages" xml:space="preserve">将被压缩提交的消息追加到正文</x:String>
   <x:String x:Key="Text.ForceSquash.StashPopFailed" xml:space="preserve">应用自动保存失败。</x:String>
-  <x:String x:Key="Text.ForceSquash.ShowFullDiff" xml:space="preserve">显示完整 diff</x:String>
   <x:String x:Key="Text.ForceSquash.Success" xml:space="preserve">历史已扁平化。备份分支：{0}</x:String>
   <x:String x:Key="Text.ForceSquash.SuccessNoBackup" xml:space="preserve">历史已扁平化。</x:String>
   <x:String x:Key="Text.SSHKey" xml:space="preserve">SSH密钥 ：</x:String>

--- a/src/Resources/Locales/zh_TW.axaml
+++ b/src/Resources/Locales/zh_TW.axaml
@@ -762,7 +762,6 @@
   <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">保留目標提交的原作者/日期</x:String>
   <x:String x:Key="Text.ForceSquash.AppendMessages" xml:space="preserve">將被壓縮的提交訊息附加到正文</x:String>
   <x:String x:Key="Text.ForceSquash.StashPopFailed" xml:space="preserve">套用自動暫存失敗。</x:String>
-  <x:String x:Key="Text.ForceSquash.ShowFullDiff" xml:space="preserve">顯示完整 diff</x:String>
   <x:String x:Key="Text.ForceSquash.Success" xml:space="preserve">歷史已扁平化。備份分支：{0}</x:String>
   <x:String x:Key="Text.ForceSquash.SuccessNoBackup" xml:space="preserve">歷史已扁平化。</x:String>
   <x:String x:Key="Text.SSHKey" xml:space="preserve">SSH 金鑰:</x:String>

--- a/src/ViewModels/ForceSquashAcrossMerges.cs
+++ b/src/ViewModels/ForceSquashAcrossMerges.cs
@@ -146,7 +146,6 @@ namespace SourceGit.ViewModels
         private List<Models.Commit> _previewCommits = new();
         private string _diffStat = string.Empty;
         private string _fullDiff = string.Empty;
-        private bool _fullDiffLoaded = false;
 
         private async Task LoadPreview()
         {
@@ -154,16 +153,8 @@ namespace SourceGit.ViewModels
             var baseSHA = Target.Parents[0];
             PreviewCommits = await new Commands.QueryCommits(_repo.FullPath, $"{Target.SHA}..{head}", false).GetResultAsync();
             DiffStat = await new Commands.DiffStat(_repo.FullPath, $"{baseSHA}..{head}").GetResultAsync();
+            FullDiff = await new Commands.DiffAll(_repo.FullPath, $"{baseSHA}..{head}").GetResultAsync();
         }
 
-        public async Task LoadFullDiff()
-        {
-            if (_fullDiffLoaded)
-                return;
-            var head = await new Commands.QueryRevisionByRefName(_repo.FullPath, "HEAD").GetResultAsync();
-            var baseSHA = Target.Parents[0];
-            FullDiff = await new Commands.DiffAll(_repo.FullPath, $"{baseSHA}..{head}").GetResultAsync();
-            _fullDiffLoaded = true;
-        }
     }
 }

--- a/src/Views/ForceSquashAcrossMerges.axaml
+++ b/src/Views/ForceSquashAcrossMerges.axaml
@@ -9,37 +9,39 @@
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SourceGit.Views.ForceSquashAcrossMerges"
              x:DataType="vm:ForceSquashAcrossMerges">
-  <StackPanel Orientation="Vertical" Margin="8,0">
-    <TextBlock FontSize="18"
-               Classes="bold"
-               Text="{DynamicResource Text.ForceSquash.Title}"/>
-    <StackPanel Margin="0,18,0,0">
-      <TextBlock Text="{DynamicResource Text.ForceSquash.Warn1}" Foreground="Red"/>
-      <TextBlock Margin="0,4,0,0" Text="{DynamicResource Text.ForceSquash.Warn2}"/>
-      <TextBlock Margin="0,4,0,0" Text="{DynamicResource Text.ForceSquash.Warn3}"/>
-      <TextBlock Margin="0,4,0,0" Text="{DynamicResource Text.ForceSquash.Warn4}"/>
-      <TextBlock Margin="0,4,0,0" Text="{DynamicResource Text.ForceSquash.Warn5}"/>
-    </StackPanel>
-    <StackPanel Margin="0,18,0,0">
-      <CheckBox Content="{DynamicResource Text.ForceSquash.CreateBackup}" IsChecked="{Binding CreateBackup, Mode=TwoWay}"/>
-      <CheckBox Content="{DynamicResource Text.ForceSquash.AutoStash}" IsChecked="{Binding AutoStash, Mode=TwoWay}"/>
-      <CheckBox Content="{DynamicResource Text.ForceSquash.KeepAuthorDate}" IsChecked="{Binding KeepAuthorDate, Mode=TwoWay}"/>
-      <CheckBox Content="{DynamicResource Text.ForceSquash.AppendMessages}" IsChecked="{Binding AppendMessages, Mode=TwoWay}"/>
-    </StackPanel>
-    <ListBox Height="120" Margin="0,18,0,0" ItemsSource="{Binding PreviewCommits}">
-      <ListBox.ItemTemplate>
-        <DataTemplate x:DataType="m:Commit">
-          <StackPanel Orientation="Horizontal">
-            <TextBlock Text="🔀" IsVisible="{Binding Parents.Count, Converter={x:Static c:IntConverters.IsNotOne}}"/>
-            <TextBlock Margin="4,0,0,0" Text="{Binding Subject}"/>
-          </StackPanel>
-        </DataTemplate>
-      </ListBox.ItemTemplate>
-    </ListBox>
-    <TextBlock Margin="0,6,0,0" Text="{Binding DiffStat}" FontFamily="{DynamicResource Fonts.Monospace}"/>
-    <Expander Margin="0,6,0,0" Header="{DynamicResource Text.ForceSquash.ShowFullDiff}" Expanded="OnShowFullDiff">
-      <TextBox Text="{Binding FullDiff}" FontFamily="{DynamicResource Fonts.Monospace}" IsReadOnly="True" AcceptsReturn="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto" MinHeight="120"/>
-    </Expander>
-    <v:CommitMessageTextBox Height="120" Margin="0,18,0,0" Text="{Binding Message, Mode=TwoWay}"/>
-  </StackPanel>
+  <Grid Margin="8,0" ColumnDefinitions="*,*" Height="400">
+    <ScrollViewer Grid.Column="0" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" Margin="0,0,12,0">
+      <StackPanel Orientation="Vertical">
+        <TextBlock FontSize="18"
+                   Classes="bold"
+                   Text="{DynamicResource Text.ForceSquash.Title}"/>
+        <StackPanel Margin="0,18,0,0">
+          <TextBlock Text="{DynamicResource Text.ForceSquash.Warn1}" Foreground="Red"/>
+          <TextBlock Margin="0,4,0,0" Text="{DynamicResource Text.ForceSquash.Warn2}"/>
+          <TextBlock Margin="0,4,0,0" Text="{DynamicResource Text.ForceSquash.Warn3}"/>
+          <TextBlock Margin="0,4,0,0" Text="{DynamicResource Text.ForceSquash.Warn4}"/>
+          <TextBlock Margin="0,4,0,0" Text="{DynamicResource Text.ForceSquash.Warn5}"/>
+        </StackPanel>
+        <StackPanel Margin="0,18,0,0">
+          <CheckBox Content="{DynamicResource Text.ForceSquash.CreateBackup}" IsChecked="{Binding CreateBackup, Mode=TwoWay}"/>
+          <CheckBox Content="{DynamicResource Text.ForceSquash.AutoStash}" IsChecked="{Binding AutoStash, Mode=TwoWay}"/>
+          <CheckBox Content="{DynamicResource Text.ForceSquash.KeepAuthorDate}" IsChecked="{Binding KeepAuthorDate, Mode=TwoWay}"/>
+          <CheckBox Content="{DynamicResource Text.ForceSquash.AppendMessages}" IsChecked="{Binding AppendMessages, Mode=TwoWay}"/>
+        </StackPanel>
+        <ListBox Height="120" Margin="0,18,0,0" ItemsSource="{Binding PreviewCommits}">
+          <ListBox.ItemTemplate>
+            <DataTemplate x:DataType="m:Commit">
+              <StackPanel Orientation="Horizontal">
+                <TextBlock Text="🔀" IsVisible="{Binding Parents.Count, Converter={x:Static c:IntConverters.IsNotOne}}"/>
+                <TextBlock Margin="4,0,0,0" Text="{Binding Subject}"/>
+              </StackPanel>
+            </DataTemplate>
+          </ListBox.ItemTemplate>
+        </ListBox>
+        <TextBlock Margin="0,6,0,0" Text="{Binding DiffStat}" FontFamily="{DynamicResource Fonts.Monospace}"/>
+        <v:CommitMessageTextBox Height="120" Margin="0,18,0,0" Text="{Binding Message, Mode=TwoWay}"/>
+      </StackPanel>
+    </ScrollViewer>
+    <TextBox Grid.Column="1" Text="{Binding FullDiff}" FontFamily="{DynamicResource Fonts.Monospace}" IsReadOnly="True" AcceptsReturn="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"/>
+  </Grid>
 </UserControl>

--- a/src/Views/ForceSquashAcrossMerges.axaml.cs
+++ b/src/Views/ForceSquashAcrossMerges.axaml.cs
@@ -1,6 +1,4 @@
 using Avalonia.Controls;
-using System;
-using Avalonia.Interactivity;
 
 namespace SourceGit.Views
 {
@@ -11,10 +9,5 @@ namespace SourceGit.Views
             InitializeComponent();
         }
 
-        private async void OnShowFullDiff(object sender, RoutedEventArgs e)
-        {
-            if (DataContext is ViewModels.ForceSquashAcrossMerges vm)
-                await vm.LoadFullDiff();
-        }
     }
 }

--- a/src/Views/LauncherPage.axaml
+++ b/src/Views/LauncherPage.axaml
@@ -53,12 +53,12 @@
               PointerPressed="OnMaskClicked"
               IsVisible="{Binding Popup, Converter={x:Static ObjectConverters.IsNotNull}}"/>
 
-      <Grid RowDefinitions="Auto,Auto,*" Width="512" HorizontalAlignment="Center">
+      <Grid RowDefinitions="Auto,Auto,*" Width="800" HorizontalAlignment="Center" VerticalAlignment="Center">
         <!-- Popup -->
         <Border Grid.Row="0"
                 Margin="6,0"
                 Effect="drop-shadow(0 0 8 #8F000000)"
-                CornerRadius="0,0,8,8"
+                CornerRadius="8"
                 ClipToBounds="True"
                 IsVisible="{Binding Popup, Converter={x:Static ObjectConverters.IsNotNull}}">
           <ContentControl Content="{Binding Popup}" Background="{DynamicResource Brush.Popup}">


### PR DESCRIPTION
## Summary
- split Force Squash dialog into scrollable options and right-hand diff view
- auto-load diff in Force Squash view model
- widen and center popup host for side-by-side layout

## Testing
- `dotnet build src/SourceGit.csproj` *(fails: A compatible .NET SDK was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3bd843338832d80aea6c5f499f366