### PR TITLE
Show changed files instead of diff in force squash popup

### DIFF
--- a/src/Views/ForceSquashAcrossMerges.axaml
+++ b/src/Views/ForceSquashAcrossMerges.axaml
@@ -38,10 +38,16 @@
             </DataTemplate>
           </ListBox.ItemTemplate>
         </ListBox>
-        <TextBlock Margin="0,6,0,0" Text="{Binding DiffStat}" FontFamily="{DynamicResource Fonts.Monospace}"/>
         <v:CommitMessageTextBox Height="120" Margin="0,18,0,0" Text="{Binding Message, Mode=TwoWay}"/>
       </StackPanel>
     </ScrollViewer>
-    <TextBox Grid.Column="1" Text="{Binding FullDiff}" FontFamily="{DynamicResource Fonts.Monospace}" IsReadOnly="True" AcceptsReturn="True" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto"/>
+    <Grid Grid.Column="1">
+      <Grid.RowDefinitions>
+        <RowDefinition Height="*"/>
+        <RowDefinition Height="Auto"/>
+      </Grid.RowDefinitions>
+      <ListBox Grid.Row="0" ItemsSource="{Binding ChangedFiles}" FontFamily="{DynamicResource Fonts.Monospace}" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto" Margin="0,0,0,6"/>
+      <TextBlock Grid.Row="1" Text="{Binding DiffStat}" FontFamily="{DynamicResource Fonts.Monospace}"/>
+    </Grid>
   </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- list changed files rather than a full diff in force squash popup
- add horizontal scrollbars and layout tweaks to avoid overlap

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68a3d2cd4508832da9f3f3b7664d4686