### PR TITLE
Simplify force squash popup layout

### DIFF
--- a/src/ViewModels/ForceSquashAcrossMerges.cs
+++ b/src/ViewModels/ForceSquashAcrossMerges.cs
@@ -12,16 +12,12 @@ namespace SourceGit.ViewModels
         public bool KeepAuthorDate { get; set; }
         public bool AppendMessages { get; set; }
         public string Message { get => _message; set => SetProperty(ref _message, value, true); }
-        public List<Models.Commit> PreviewCommits { get => _previewCommits; set => SetProperty(ref _previewCommits, value); }
-        public string DiffStat { get => _diffStat; set => SetProperty(ref _diffStat, value); }
-        public List<string> ChangedFiles { get => _changedFiles; set => SetProperty(ref _changedFiles, value); }
 
         public ForceSquashAcrossMerges(Repository repo, Models.Commit target)
         {
             _repo = repo;
             Target = target;
             _message = target.Subject;
-            Task.Run(LoadPreview);
         }
 
         public override async Task<bool> Sure()
@@ -143,38 +139,6 @@ namespace SourceGit.ViewModels
 
         private readonly Repository _repo;
         private string _message;
-        private List<Models.Commit> _previewCommits = new();
-        private string _diffStat = string.Empty;
-        private List<string> _changedFiles = new();
-
-        private async Task LoadPreview()
-        {
-            var head = await new Commands.QueryRevisionByRefName(_repo.FullPath, "HEAD").GetResultAsync();
-            var baseSHA = Target.Parents[0];
-            PreviewCommits = await new Commands.QueryCommits(_repo.FullPath, $"{Target.SHA}..{head}", false).GetResultAsync();
-            var stat = await new Commands.DiffStat(_repo.FullPath, $"{baseSHA}..{head}").GetResultAsync();
-            if (string.IsNullOrEmpty(stat))
-            {
-                DiffStat = string.Empty;
-                ChangedFiles = new List<string>();
-                return;
-            }
-            var lines = stat.Split('\n');
-            var files = new List<string>();
-            for (var i = 0; i < lines.Length; i++)
-            {
-                var line = lines[i];
-                if (i == lines.Length - 1)
-                    DiffStat = line;
-                else
-                {
-                    var idx = line.IndexOf('|');
-                    if (idx > 0)
-                        files.Add(line.Substring(0, idx).Trim());
-                }
-            }
-            ChangedFiles = files;
-        }
 
     }
 }

--- a/src/Views/CommitMessageTextBox.axaml
+++ b/src/Views/CommitMessageTextBox.axaml
@@ -49,7 +49,7 @@
                          AcceptsTab="True"
                          TextWrapping="Wrap"
                          ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                         ScrollViewer.VerticalScrollBarVisibility="Auto"
+                         ScrollViewer.VerticalScrollBarVisibility="Disabled"
                          Text="{Binding #ThisControl.Description, Mode=TwoWay}"
                          Watermark="{DynamicResource Text.CommitMessageTextBox.MessagePlaceholder}"
                          PreviewKeyDown="OnDescriptionTextBoxPreviewKeyDown"

--- a/src/Views/ForceSquashAcrossMerges.axaml
+++ b/src/Views/ForceSquashAcrossMerges.axaml
@@ -4,50 +4,28 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:SourceGit.ViewModels"
              xmlns:v="using:SourceGit.Views"
-             xmlns:m="using:SourceGit.Models"
-             xmlns:c="using:SourceGit.Converters"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SourceGit.Views.ForceSquashAcrossMerges"
              x:DataType="vm:ForceSquashAcrossMerges">
-  <Grid Margin="8,0" ColumnDefinitions="*,*" Height="400">
-    <ScrollViewer Grid.Column="0" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" Margin="0,0,12,0">
-      <StackPanel Orientation="Vertical">
-        <TextBlock FontSize="18"
-                   Classes="bold"
-                   Text="{DynamicResource Text.ForceSquash.Title}"/>
-        <StackPanel Margin="0,18,0,0">
-          <TextBlock Text="{DynamicResource Text.ForceSquash.Warn1}" Foreground="Red"/>
-          <TextBlock Margin="0,4,0,0" Text="{DynamicResource Text.ForceSquash.Warn2}"/>
-          <TextBlock Margin="0,4,0,0" Text="{DynamicResource Text.ForceSquash.Warn3}"/>
-          <TextBlock Margin="0,4,0,0" Text="{DynamicResource Text.ForceSquash.Warn4}"/>
-          <TextBlock Margin="0,4,0,0" Text="{DynamicResource Text.ForceSquash.Warn5}"/>
-        </StackPanel>
-        <StackPanel Margin="0,18,0,0">
-          <CheckBox Content="{DynamicResource Text.ForceSquash.CreateBackup}" IsChecked="{Binding CreateBackup, Mode=TwoWay}"/>
-          <CheckBox Content="{DynamicResource Text.ForceSquash.AutoStash}" IsChecked="{Binding AutoStash, Mode=TwoWay}"/>
-          <CheckBox Content="{DynamicResource Text.ForceSquash.KeepAuthorDate}" IsChecked="{Binding KeepAuthorDate, Mode=TwoWay}"/>
-          <CheckBox Content="{DynamicResource Text.ForceSquash.AppendMessages}" IsChecked="{Binding AppendMessages, Mode=TwoWay}"/>
-        </StackPanel>
-        <ListBox Height="120" Margin="0,18,0,0" ItemsSource="{Binding PreviewCommits}">
-          <ListBox.ItemTemplate>
-            <DataTemplate x:DataType="m:Commit">
-              <StackPanel Orientation="Horizontal">
-                <TextBlock Text="🔀" IsVisible="{Binding Parents.Count, Converter={x:Static c:IntConverters.IsNotOne}}"/>
-                <TextBlock Margin="4,0,0,0" Text="{Binding Subject}"/>
-              </StackPanel>
-            </DataTemplate>
-          </ListBox.ItemTemplate>
-        </ListBox>
-        <v:CommitMessageTextBox Height="120" Margin="0,18,0,0" Text="{Binding Message, Mode=TwoWay}"/>
+  <DockPanel Margin="8,0" Height="400">
+    <v:CommitMessageTextBox DockPanel.Dock="Bottom" Height="120" Margin="0,18,0,0" Text="{Binding Message, Mode=TwoWay}"/>
+    <StackPanel Orientation="Vertical">
+      <TextBlock FontSize="18"
+                 Classes="bold"
+                 Text="{DynamicResource Text.ForceSquash.Title}"/>
+      <StackPanel Margin="0,18,0,0">
+        <TextBlock Text="{DynamicResource Text.ForceSquash.Warn1}" Foreground="Red"/>
+        <TextBlock Margin="0,4,0,0" Text="{DynamicResource Text.ForceSquash.Warn2}"/>
+        <TextBlock Margin="0,4,0,0" Text="{DynamicResource Text.ForceSquash.Warn3}"/>
+        <TextBlock Margin="0,4,0,0" Text="{DynamicResource Text.ForceSquash.Warn4}"/>
+        <TextBlock Margin="0,4,0,0" Text="{DynamicResource Text.ForceSquash.Warn5}"/>
       </StackPanel>
-    </ScrollViewer>
-    <Grid Grid.Column="1">
-      <Grid.RowDefinitions>
-        <RowDefinition Height="*"/>
-        <RowDefinition Height="Auto"/>
-      </Grid.RowDefinitions>
-      <ListBox Grid.Row="0" ItemsSource="{Binding ChangedFiles}" FontFamily="{DynamicResource Fonts.Monospace}" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto" Margin="0,0,0,6"/>
-      <TextBlock Grid.Row="1" Text="{Binding DiffStat}" FontFamily="{DynamicResource Fonts.Monospace}"/>
-    </Grid>
-  </Grid>
+      <StackPanel Margin="0,18,0,0">
+        <CheckBox Content="{DynamicResource Text.ForceSquash.CreateBackup}" IsChecked="{Binding CreateBackup, Mode=TwoWay}"/>
+        <CheckBox Content="{DynamicResource Text.ForceSquash.AutoStash}" IsChecked="{Binding AutoStash, Mode=TwoWay}"/>
+        <CheckBox Content="{DynamicResource Text.ForceSquash.KeepAuthorDate}" IsChecked="{Binding KeepAuthorDate, Mode=TwoWay}"/>
+        <CheckBox Content="{DynamicResource Text.ForceSquash.AppendMessages}" IsChecked="{Binding AppendMessages, Mode=TwoWay}"/>
+      </StackPanel>
+    </StackPanel>
+  </DockPanel>
 </UserControl>


### PR DESCRIPTION
## Summary
- remove commit and file lists from force squash popup
- disable scrollbars and keep commit message editor full width

## Testing
- `dotnet build` *(fails: A compatible .NET SDK was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d8d78138832d89ce7df1806b2cd3