### PR TITLE
Revert unrelated GUI adjustments

### DIFF
--- a/src/Views/CommitMessageTextBox.axaml
+++ b/src/Views/CommitMessageTextBox.axaml
@@ -49,7 +49,7 @@
                          AcceptsTab="True"
                          TextWrapping="Wrap"
                          ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                         ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                         ScrollViewer.VerticalScrollBarVisibility="Auto"
                          Text="{Binding #ThisControl.Description, Mode=TwoWay}"
                          Watermark="{DynamicResource Text.CommitMessageTextBox.MessagePlaceholder}"
                          PreviewKeyDown="OnDescriptionTextBoxPreviewKeyDown"

--- a/src/Views/LauncherPage.axaml
+++ b/src/Views/LauncherPage.axaml
@@ -53,12 +53,12 @@
               PointerPressed="OnMaskClicked"
               IsVisible="{Binding Popup, Converter={x:Static ObjectConverters.IsNotNull}}"/>
 
-      <Grid RowDefinitions="Auto,Auto,*" Width="800" HorizontalAlignment="Center" VerticalAlignment="Center">
+      <Grid RowDefinitions="Auto,Auto,*" Width="512" HorizontalAlignment="Center">
         <!-- Popup -->
         <Border Grid.Row="0"
                 Margin="6,0"
                 Effect="drop-shadow(0 0 8 #8F000000)"
-                CornerRadius="8"
+                CornerRadius="0,0,8,8"
                 ClipToBounds="True"
                 IsVisible="{Binding Popup, Converter={x:Static ObjectConverters.IsNotNull}}">
           <ContentControl Content="{Binding Popup}" Background="{DynamicResource Brush.Popup}">


### PR DESCRIPTION
## Summary
- Restore scroll behavior in commit message editor
- Revert popup sizing tweaks on launcher page

## Testing
- `dotnet build src/SourceGit.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a3dde3eaec832dba50b124d1f66373