### PR TITLE
Use single TextBlock for force squash warnings

### DIFF
--- a/src/Views/ForceSquashAcrossMerges.axaml
+++ b/src/Views/ForceSquashAcrossMerges.axaml
@@ -14,11 +14,13 @@
                  Classes="bold"
                  Text="{DynamicResource Text.ForceSquash.Title}"/>
       <StackPanel Margin="0,18,0,0">
-        <TextBlock Text="{DynamicResource Text.ForceSquash.Warn1}" Foreground="Red"/>
-        <TextBlock Margin="0,4,0,0" Text="{DynamicResource Text.ForceSquash.Warn2}"/>
-        <TextBlock Margin="0,4,0,0" Text="{DynamicResource Text.ForceSquash.Warn3}"/>
-        <TextBlock Margin="0,4,0,0" Text="{DynamicResource Text.ForceSquash.Warn4}"/>
-        <TextBlock Margin="0,4,0,0" Text="{DynamicResource Text.ForceSquash.Warn5}"/>
+        <TextBlock Foreground="Red" TextWrapping="Wrap">
+          <Run Text="{DynamicResource Text.ForceSquash.Warn1}"/><LineBreak/>
+          <Run Text="{DynamicResource Text.ForceSquash.Warn2}"/><LineBreak/>
+          <Run Text="{DynamicResource Text.ForceSquash.Warn3}"/><LineBreak/>
+          <Run Text="{DynamicResource Text.ForceSquash.Warn4}"/><LineBreak/>
+          <Run Text="{DynamicResource Text.ForceSquash.Warn5}"/>
+        </TextBlock>
       </StackPanel>
       <StackPanel Margin="0,18,0,0">
         <CheckBox Content="{DynamicResource Text.ForceSquash.CreateBackup}" IsChecked="{Binding CreateBackup, Mode=TwoWay}"/>


### PR DESCRIPTION
## Summary
- consolidate force squash warnings into one multi-line TextBlock

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a40523771c832d90fec08d5d431402