### PR TITLE
Combine Force Squash warnings

### DIFF
--- a/src/Resources/Locales/de_DE.axaml
+++ b/src/Resources/Locales/de_DE.axaml
@@ -753,11 +753,11 @@
   <x:String x:Key="Text.Squash" xml:space="preserve">Squash Commits</x:String>
   <x:String x:Key="Text.Squash.Into" xml:space="preserve">In:</x:String>
   <x:String x:Key="Text.ForceSquash.Title" xml:space="preserve">Squash über Merges (Historie glätten)</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn1" xml:space="preserve">Operation überschreibt die Historie vom gewählten Commit bis HEAD zu einem Commit</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn2" xml:space="preserve">Alle Merge-Commits im Bereich werden entfernt</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn3" xml:space="preserve">Signierte Commits oder Merges verlieren Signaturen</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn4" xml:space="preserve">Anschließend ist ein Force-Push erforderlich</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn5" xml:space="preserve">Schließe oder aktualisiere alle zugehörigen MR/PR</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn" xml:space="preserve">Operation überschreibt die Historie vom gewählten Commit bis HEAD zu einem Commit
+Alle Merge-Commits im Bereich werden entfernt
+Signierte Commits oder Merges verlieren Signaturen
+Anschließend ist ein Force-Push erforderlich
+Schließe oder aktualisiere alle zugehörigen MR/PR</x:String>
   <x:String x:Key="Text.ForceSquash.CreateBackup" xml:space="preserve">Vor dem Überschreiben Sicherungszweig erstellen</x:String>
   <x:String x:Key="Text.ForceSquash.AutoStash" xml:space="preserve">Lokale Änderungen automatisch stashen</x:String>
   <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">Originalautor und -datum des Ziel-Commits beibehalten</x:String>

--- a/src/Resources/Locales/en_US.axaml
+++ b/src/Resources/Locales/en_US.axaml
@@ -749,11 +749,11 @@
   <x:String x:Key="Text.Squash" xml:space="preserve">Squash Commits</x:String>
   <x:String x:Key="Text.Squash.Into" xml:space="preserve">Into:</x:String>
   <x:String x:Key="Text.ForceSquash.Title" xml:space="preserve">Squash across merges (flatten history)</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn1" xml:space="preserve">Operation rewrites history from selected commit to HEAD into one commit</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn2" xml:space="preserve">All merge commits in range will be removed</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn3" xml:space="preserve">Signed commits or merges lose signatures</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn4" xml:space="preserve">Force push is required afterwards</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn5" xml:space="preserve">Close or update any related MR/PR</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn" xml:space="preserve">Operation rewrites history from selected commit to HEAD into one commit
+All merge commits in range will be removed
+Signed commits or merges lose signatures
+Force push is required afterwards
+Close or update any related MR/PR</x:String>
   <x:String x:Key="Text.ForceSquash.CreateBackup" xml:space="preserve">Create safety backup branch before rewrite</x:String>
   <x:String x:Key="Text.ForceSquash.AutoStash" xml:space="preserve">Auto-stash local changes</x:String>
   <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">Keep original author/date of target commit</x:String>

--- a/src/Resources/Locales/es_ES.axaml
+++ b/src/Resources/Locales/es_ES.axaml
@@ -752,11 +752,11 @@
   <x:String x:Key="Text.Squash" xml:space="preserve">Squash Commits</x:String>
   <x:String x:Key="Text.Squash.Into" xml:space="preserve">En:</x:String>
   <x:String x:Key="Text.ForceSquash.Title" xml:space="preserve">Squash a través de merges (aplanar historial)</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn1" xml:space="preserve">La operación reescribe el historial desde el commit seleccionado hasta HEAD en un solo commit</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn2" xml:space="preserve">Todos los commits de merge en el rango serán eliminados</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn3" xml:space="preserve">Los commits o merges firmados pierden sus firmas</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn4" xml:space="preserve">Se requiere un force push después</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn5" xml:space="preserve">Cierra o actualiza cualquier MR/PR relacionado</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn" xml:space="preserve">La operación reescribe el historial desde el commit seleccionado hasta HEAD en un solo commit
+Todos los commits de merge en el rango serán eliminados
+Los commits o merges firmados pierden sus firmas
+Se requiere un force push después
+Cierra o actualiza cualquier MR/PR relacionado</x:String>
   <x:String x:Key="Text.ForceSquash.CreateBackup" xml:space="preserve">Crear rama de respaldo antes de sobrescribir</x:String>
   <x:String x:Key="Text.ForceSquash.AutoStash" xml:space="preserve">Guardar automáticamente los cambios locales</x:String>
   <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">Conservar autor/fecha originales del commit destino</x:String>

--- a/src/Resources/Locales/fr_FR.axaml
+++ b/src/Resources/Locales/fr_FR.axaml
@@ -613,11 +613,11 @@
   <x:String x:Key="Text.Squash" xml:space="preserve">Squash les commits</x:String>
   <x:String x:Key="Text.Squash.Into" xml:space="preserve">Dans :</x:String>
   <x:String x:Key="Text.ForceSquash.Title" xml:space="preserve">Squasher à travers les fusions (aplatir l'historique)</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn1" xml:space="preserve">L'opération réécrit l'historique du commit sélectionné jusqu'à HEAD en un seul commit</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn2" xml:space="preserve">Tous les commits de fusion dans l'intervalle seront supprimés</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn3" xml:space="preserve">Les commits ou fusions signés perdent leurs signatures</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn4" xml:space="preserve">Un push forcé est nécessaire ensuite</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn5" xml:space="preserve">Fermez ou mettez à jour toute MR/PR liée</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn" xml:space="preserve">L'opération réécrit l'historique du commit sélectionné jusqu'à HEAD en un seul commit
+Tous les commits de fusion dans l'intervalle seront supprimés
+Les commits ou fusions signés perdent leurs signatures
+Un push forcé est nécessaire ensuite
+Fermez ou mettez à jour toute MR/PR liée</x:String>
   <x:String x:Key="Text.ForceSquash.CreateBackup" xml:space="preserve">Créer une branche de sauvegarde avant la réécriture</x:String>
   <x:String x:Key="Text.ForceSquash.AutoStash" xml:space="preserve">Stasher automatiquement les modifications locales</x:String>
   <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">Conserver l'auteur/la date originaux du commit cible</x:String>

--- a/src/Resources/Locales/it_IT.axaml
+++ b/src/Resources/Locales/it_IT.axaml
@@ -641,11 +641,11 @@
   <x:String x:Key="Text.Squash" xml:space="preserve">Compatta Commit</x:String>
   <x:String x:Key="Text.Squash.Into" xml:space="preserve">In:</x:String>
   <x:String x:Key="Text.ForceSquash.Title" xml:space="preserve">Squash attraverso i merge (appiattisci la cronologia)</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn1" xml:space="preserve">L'operazione riscrive la cronologia dal commit selezionato a HEAD in un solo commit</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn2" xml:space="preserve">Tutti i commit di merge nell'intervallo saranno rimossi</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn3" xml:space="preserve">I commit o i merge firmati perdono le firme</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn4" xml:space="preserve">È richiesto un force push dopo</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn5" xml:space="preserve">Chiudi o aggiorna qualsiasi MR/PR correlato</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn" xml:space="preserve">L'operazione riscrive la cronologia dal commit selezionato a HEAD in un solo commit
+Tutti i commit di merge nell'intervallo saranno rimossi
+I commit o i merge firmati perdono le firme
+È richiesto un force push dopo
+Chiudi o aggiorna qualsiasi MR/PR correlato</x:String>
   <x:String x:Key="Text.ForceSquash.CreateBackup" xml:space="preserve">Crea un ramo di backup prima della riscrittura</x:String>
   <x:String x:Key="Text.ForceSquash.AutoStash" xml:space="preserve">Esegui auto-stash delle modifiche locali</x:String>
   <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">Mantieni autore/data originali del commit di destinazione</x:String>

--- a/src/Resources/Locales/ja_JP.axaml
+++ b/src/Resources/Locales/ja_JP.axaml
@@ -611,11 +611,11 @@
   <x:String x:Key="Text.Squash" xml:space="preserve">スカッシュコミット</x:String>
   <x:String x:Key="Text.Squash.Into" xml:space="preserve">宛先:</x:String>
   <x:String x:Key="Text.ForceSquash.Title" xml:space="preserve">マージをまたいでスクワッシュ（履歴を平坦化）</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn1" xml:space="preserve">選択したコミットからHEADまでの履歴を1つのコミットに書き換えます</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn2" xml:space="preserve">範囲内のすべてのマージコミットは削除されます</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn3" xml:space="preserve">署名付きのコミットやマージは署名を失います</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn4" xml:space="preserve">その後は強制プッシュが必要です</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn5" xml:space="preserve">関連するMR/PRを閉じるか更新してください</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn" xml:space="preserve">選択したコミットからHEADまでの履歴を1つのコミットに書き換えます
+範囲内のすべてのマージコミットは削除されます
+署名付きのコミットやマージは署名を失います
+その後は強制プッシュが必要です
+関連するMR/PRを閉じるか更新してください</x:String>
   <x:String x:Key="Text.ForceSquash.CreateBackup" xml:space="preserve">書き換え前に安全なバックアップブランチを作成</x:String>
   <x:String x:Key="Text.ForceSquash.AutoStash" xml:space="preserve">ローカル変更を自動でスタッシュ</x:String>
   <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">対象コミットの元の作者/日付を保持</x:String>

--- a/src/Resources/Locales/pt_BR.axaml
+++ b/src/Resources/Locales/pt_BR.axaml
@@ -555,11 +555,11 @@
   <x:String x:Key="Text.Squash" xml:space="preserve">Squash Commits</x:String>
   <x:String x:Key="Text.Squash.Into" xml:space="preserve">Squash commits em:</x:String>
   <x:String x:Key="Text.ForceSquash.Title" xml:space="preserve">Squash através dos merges (achatar histórico)</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn1" xml:space="preserve">A operação reescreve o histórico do commit selecionado até o HEAD em um único commit</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn2" xml:space="preserve">Todos os commits de merge no intervalo serão removidos</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn3" xml:space="preserve">Commits ou merges assinados perdem as assinaturas</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn4" xml:space="preserve">Um force push é necessário depois</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn5" xml:space="preserve">Feche ou atualize qualquer MR/PR relacionado</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn" xml:space="preserve">A operação reescreve o histórico do commit selecionado até o HEAD em um único commit
+Todos os commits de merge no intervalo serão removidos
+Commits ou merges assinados perdem as assinaturas
+Um force push é necessário depois
+Feche ou atualize qualquer MR/PR relacionado</x:String>
   <x:String x:Key="Text.ForceSquash.CreateBackup" xml:space="preserve">Criar branch de backup antes de reescrever</x:String>
   <x:String x:Key="Text.ForceSquash.AutoStash" xml:space="preserve">Auto-stash das alterações locais</x:String>
   <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">Manter autor/data originais do commit de destino</x:String>

--- a/src/Resources/Locales/ru_RU.axaml
+++ b/src/Resources/Locales/ru_RU.axaml
@@ -742,11 +742,11 @@
   <x:String x:Key="Text.Squash" xml:space="preserve">Втиснуть ревизии</x:String>
   <x:String x:Key="Text.Squash.Into" xml:space="preserve">В:</x:String>
   <x:String x:Key="Text.ForceSquash.Title" xml:space="preserve">Втиснуть через слияния (выпрямить историю)</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn1" xml:space="preserve">Операция перепишет историю от выбранного коммита до HEAD в один коммит</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn2" xml:space="preserve">Все merge-коммиты в диапазоне будут удалены</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn3" xml:space="preserve">Подписи коммитов и merge будут потеряны</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn4" xml:space="preserve">Далее потребуется принудительная отправка</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn5" xml:space="preserve">Закройте или обновите связанные MR/PR</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn" xml:space="preserve">Операция перепишет историю от выбранного коммита до HEAD в один коммит
+Все merge-коммиты в диапазоне будут удалены
+Подписи коммитов и merge будут потеряны
+Далее потребуется принудительная отправка
+Закройте или обновите связанные MR/PR</x:String>
   <x:String x:Key="Text.ForceSquash.CreateBackup" xml:space="preserve">Создать резервную ветку перед переписыванием</x:String>
   <x:String x:Key="Text.ForceSquash.AutoStash" xml:space="preserve">Авто-сохранение локальных изменений</x:String>
   <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">Сохранить автора и дату целевого коммита</x:String>

--- a/src/Resources/Locales/ta_IN.axaml
+++ b/src/Resources/Locales/ta_IN.axaml
@@ -612,11 +612,11 @@
   <x:String x:Key="Text.Squash" xml:space="preserve">நொறுக்கு உறுதிமொழிகள்</x:String>
   <x:String x:Key="Text.Squash.Into" xml:space="preserve">இதில்:</x:String>
   <x:String x:Key="Text.ForceSquash.Title" xml:space="preserve">இணைப்புகளை தாண்டி நொறுக்கு (வரலாற்றை சமப்படுத்து)</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn1" xml:space="preserve">தேர்ந்தெடுக்கப்பட்ட commit-இலிருந்து HEAD வரை வரலாறு ஒரே commit-ஆக மாற்றப்படும்</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn2" xml:space="preserve">வரம்பில் உள்ள merge commit-கள் அனைத்தும் அகற்றப்படும்</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn3" xml:space="preserve">கையொப்பமிட்ட commit-கள் அல்லது merge-கள் கையொப்பங்களை இழக்கும்</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn4" xml:space="preserve">பிறகு force push தேவை</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn5" xml:space="preserve">தொடர்புடைய MR/PR-ஐ மூட அல்லது புதுப்பிக்கவும்</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn" xml:space="preserve">தேர்ந்தெடுக்கப்பட்ட commit-இலிருந்து HEAD வரை வரலாறு ஒரே commit-ஆக மாற்றப்படும்
+வரம்பில் உள்ள merge commit-கள் அனைத்தும் அகற்றப்படும்
+கையொப்பமிட்ட commit-கள் அல்லது merge-கள் கையொப்பங்களை இழக்கும்
+பிறகு force push தேவை
+தொடர்புடைய MR/PR-ஐ மூட அல்லது புதுப்பிக்கவும்</x:String>
   <x:String x:Key="Text.ForceSquash.CreateBackup" xml:space="preserve">மீண்டும் எழுதுவதற்கு முன் பாதுகாப்பு காப்பு branch உருவாக்கவும்</x:String>
   <x:String x:Key="Text.ForceSquash.AutoStash" xml:space="preserve">உள்ளூர் மாற்றங்களை தானாக stash செய்</x:String>
   <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">இலக்கு commit-ன் அசல் author/தேதியை வைத்திரு</x:String>

--- a/src/Resources/Locales/uk_UA.axaml
+++ b/src/Resources/Locales/uk_UA.axaml
@@ -617,11 +617,11 @@
   <x:String x:Key="Text.Squash" xml:space="preserve">Squash (Склеїти коміти)</x:String>
   <x:String x:Key="Text.Squash.Into" xml:space="preserve">В:</x:String>
   <x:String x:Key="Text.ForceSquash.Title" xml:space="preserve">Сплющити через мерджі (вирівняти історію)</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn1" xml:space="preserve">Операція перепише історію від вибраного коміту до HEAD в один коміт</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn2" xml:space="preserve">Усі коміти злиття в діапазоні буде вилучено</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn3" xml:space="preserve">Підписані коміти або злиття втратять підписи</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn4" xml:space="preserve">Після цього потрібен примусовий push</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn5" xml:space="preserve">Закрийте або оновіть пов’язані MR/PR</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn" xml:space="preserve">Операція перепише історію від вибраного коміту до HEAD в один коміт
+Усі коміти злиття в діапазоні буде вилучено
+Підписані коміти або злиття втратять підписи
+Після цього потрібен примусовий push
+Закрийте або оновіть пов’язані MR/PR</x:String>
   <x:String x:Key="Text.ForceSquash.CreateBackup" xml:space="preserve">Створити резервну гілку перед переписуванням</x:String>
   <x:String x:Key="Text.ForceSquash.AutoStash" xml:space="preserve">Автоматично застешити локальні зміни</x:String>
   <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">Зберегти автора/дату цільового коміту</x:String>

--- a/src/Resources/Locales/zh_CN.axaml
+++ b/src/Resources/Locales/zh_CN.axaml
@@ -752,11 +752,11 @@
   <x:String x:Key="Text.Squash" xml:space="preserve">压缩为单个提交</x:String>
   <x:String x:Key="Text.Squash.Into" xml:space="preserve">合并入：</x:String>
   <x:String x:Key="Text.ForceSquash.Title" xml:space="preserve">跨合并压缩（扁平化历史）</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn1" xml:space="preserve">操作会把从选定提交到 HEAD 的历史重写为一个提交</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn2" xml:space="preserve">范围内的所有合并提交都会被移除</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn3" xml:space="preserve">签名的提交或合并将丢失签名</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn4" xml:space="preserve">之后需要强制推送</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn5" xml:space="preserve">请关闭或更新相关的 MR/PR</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn" xml:space="preserve">操作会把从选定提交到 HEAD 的历史重写为一个提交
+范围内的所有合并提交都会被移除
+签名的提交或合并将丢失签名
+之后需要强制推送
+请关闭或更新相关的 MR/PR</x:String>
   <x:String x:Key="Text.ForceSquash.CreateBackup" xml:space="preserve">重写前创建安全备份分支</x:String>
   <x:String x:Key="Text.ForceSquash.AutoStash" xml:space="preserve">自动保存本地更改</x:String>
   <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">保留目标提交的原作者/日期</x:String>

--- a/src/Resources/Locales/zh_TW.axaml
+++ b/src/Resources/Locales/zh_TW.axaml
@@ -752,11 +752,11 @@
   <x:String x:Key="Text.Squash" xml:space="preserve">壓縮為單個提交</x:String>
   <x:String x:Key="Text.Squash.Into" xml:space="preserve">合併入:</x:String>
   <x:String x:Key="Text.ForceSquash.Title" xml:space="preserve">跨合併壓縮（扁平化歷史）</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn1" xml:space="preserve">操作會將從選定提交到 HEAD 的歷史重寫為單一提交</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn2" xml:space="preserve">範圍內的所有合併提交都會被移除</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn3" xml:space="preserve">簽名的提交或合併會失去簽章</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn4" xml:space="preserve">之後需要強制推送</x:String>
-  <x:String x:Key="Text.ForceSquash.Warn5" xml:space="preserve">請關閉或更新相關的 MR/PR</x:String>
+  <x:String x:Key="Text.ForceSquash.Warn" xml:space="preserve">操作會將從選定提交到 HEAD 的歷史重寫為單一提交
+範圍內的所有合併提交都會被移除
+簽名的提交或合併會失去簽章
+之後需要強制推送
+請關閉或更新相關的 MR/PR</x:String>
   <x:String x:Key="Text.ForceSquash.CreateBackup" xml:space="preserve">重寫前建立安全備份分支</x:String>
   <x:String x:Key="Text.ForceSquash.AutoStash" xml:space="preserve">自動暫存本地變更</x:String>
   <x:String x:Key="Text.ForceSquash.KeepAuthorDate" xml:space="preserve">保留目標提交的原作者/日期</x:String>

--- a/src/Views/ForceSquashAcrossMerges.axaml
+++ b/src/Views/ForceSquashAcrossMerges.axaml
@@ -13,15 +13,7 @@
       <TextBlock FontSize="18"
                  Classes="bold"
                  Text="{DynamicResource Text.ForceSquash.Title}"/>
-      <StackPanel Margin="0,18,0,0">
-        <TextBlock Foreground="Red" TextWrapping="Wrap">
-          <Run Text="{DynamicResource Text.ForceSquash.Warn1}"/><LineBreak/>
-          <Run Text="{DynamicResource Text.ForceSquash.Warn2}"/><LineBreak/>
-          <Run Text="{DynamicResource Text.ForceSquash.Warn3}"/><LineBreak/>
-          <Run Text="{DynamicResource Text.ForceSquash.Warn4}"/><LineBreak/>
-          <Run Text="{DynamicResource Text.ForceSquash.Warn5}"/>
-        </TextBlock>
-      </StackPanel>
+      <TextBlock Margin="0,4,0,0" Foreground="Red" TextWrapping="Wrap" Text="{DynamicResource Text.ForceSquash.Warn}"/>
       <StackPanel Margin="0,18,0,0">
         <CheckBox Content="{DynamicResource Text.ForceSquash.CreateBackup}" IsChecked="{Binding CreateBackup, Mode=TwoWay}"/>
         <CheckBox Content="{DynamicResource Text.ForceSquash.AutoStash}" IsChecked="{Binding AutoStash, Mode=TwoWay}"/>


### PR DESCRIPTION
## Summary
- replace multiple warning runs with single TextBlock
- consolidate Force Squash warning strings into one resource across locales

## Testing
- `~/.dotnet/dotnet build src/SourceGit.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a42b2bc5e4832d899cf221a85f6fc6